### PR TITLE
No nonce randomization

### DIFF
--- a/draft-irtf-cfrg-aead-limits.md
+++ b/draft-irtf-cfrg-aead-limits.md
@@ -481,7 +481,7 @@ q + v <= (p * 2^127 - 2^79) / (l * B)
 ~~~
 
 This assumes that B is much larger than 100; that is, each user enciphers
-significantly more than 1600 bytes of data.  B should be increased by 161 for
+significantly more than 1600 bytes of data.  Otherwise, B should be increased by 161 for
 AEAD_AES_128_GCM and by 97 for AEAD_AES_256_GCM.
 
 Protocols without nonce randomization have limits that are essentially the

--- a/draft-irtf-cfrg-aead-limits.md
+++ b/draft-irtf-cfrg-aead-limits.md
@@ -484,7 +484,7 @@ This assumes that B is much larger than 100; that is, each user enciphers
 significantly more than 1600 bytes of data.  B should be increased by 161 for
 AEAD_AES_128_GCM and by 97 for AEAD_AES_256_GCM.
 
-Protocols without nonce randomization have limits that are substantially the
+Protocols without nonce randomization have limits that are essentially the
 same provided that p is not less than 2<sup>-48</sup>, as the simplified
 expression for AEA does not include the 2<sup>-48</sup> term:
 

--- a/draft-irtf-cfrg-aead-limits.md
+++ b/draft-irtf-cfrg-aead-limits.md
@@ -481,7 +481,7 @@ q + v <= (p * 2^127 - 2^79) / (l * B)
 ~~~
 
 This assumes that B is much larger than 100; that is, each user enciphers
-significantly more than 1600 bytes of data.  B should be increased by 97.5 for
+significantly more than 1600 bytes of data.  B should be increased by 161 for
 AEAD_AES_128_GCM and by 97 for AEAD_AES_256_GCM.
 
 Protocols without nonce randomization have limits that are substantially the
@@ -492,7 +492,7 @@ expression for AEA does not include the 2<sup>-48</sup> term:
 q + v <= p * 2^127 / (l * B)
 ~~~
 
-Without nonce randomization, B should be increased by an additional 64.
+Without nonce randomization, B should be increased by an additional 0.5.
 
 
 ### Confidentiality Limit

--- a/draft-irtf-cfrg-aead-limits.md
+++ b/draft-irtf-cfrg-aead-limits.md
@@ -110,6 +110,7 @@ informative:
       - ins: D. A. McGrew
       - ins: S. R. Fluhrer
     date: 2005-05-31
+  TLS: RFC8446
 
 --- abstract
 
@@ -165,7 +166,7 @@ the usage, such as number of protected messages or amount of data transferred,
 ensures that it is easy to apply limits.  This might require the application of
 simplifying assumptions.  For example, TLS 1.3 specifies limits on the number of
 records that can be protected, using the simplifying assumption that records are
-the same size; see Section 5.5 of {{?TLS=RFC8446}}.
+the same size; see {{Section 5.5 of TLS}}.
 
 Currently, AEAD limits and usage requirements are scattered among peer-reviewed
 papers, standards documents, and other RFCs. Determining the correct limits for
@@ -240,8 +241,8 @@ AEA <= CA + IA
 ~~~
 
 Each application requires an individual determination of limits in order to keep CA
-and IA sufficiently small.  For instance, TLS aims to keep CA below 2^-60 and IA
-below 2^-57 (in the single-key setting). See {{?TLS=RFC8446}}, Section 5.5.
+and IA sufficiently small.  For instance, TLS aims to keep CA below 2<sup>-60</sup> and IA
+below 2<sup>-57</sup> in the single-key setting; see {{Section 5.5 of TLS}}.
 
 # Calculating Limits
 
@@ -427,12 +428,15 @@ Alongside each value, we also specify these bounds.
 
 Concrete multi-key bounds for AEAD_AES_128_GCM and AEAD_AES_256_GCM exist due to
 Theorem 4.3 in {{GCM-MU2}}, which covers protocols with nonce randomization,
-like TLS 1.3 {{?RFC8446}} and QUIC {{?RFC9001}}.
+like TLS 1.3 {{TLS}} and QUIC {{?RFC9001}}.
 
 Results for AES-GCM without nonce randomization are captured by Theorem 3.1 in
-{{GCM-MU2}}, which apply to protocols such as TLS 1.2 {{?RFC5246}}.
+{{GCM-MU2}}, which apply to protocols such as TLS 1.2 {{?RFC5246}}.  This
+produces similar limits under most conditions.
 
-For this AEAD, n = 128, t = 128, and r = 96; the key length is k = 128 or k = 256.
+For this AEAD, n = 128, t = 128, and r = 96; the key length is k = 128 or k =
+256 for AEAD_AES_128_GCM and AEAD_AES_128_GCM respectively.
+
 
 ### Authenticated Encryption Security Limit {#mu-gcm-ae}
 
@@ -453,6 +457,8 @@ For this AEAD, n = 128, t = 128, and r = 96; the key length is k = 128 or k = 25
           For k = 128, it is negligible if o, (q+v)*l <= 2^70.
           For o <= 2^70 and B >= 2^8, it is dominated by the 2nd term;
             we assume that and hence omit the 1st term.
+          If B is small and k = 128, then \sigma might be relevant and
+            we can add \sigma/2^128
         - 2nd term (../2^n):
           \sigma*(2B + cn + 2) = \sigma*(B + 97)/2^127 in Theorem 4.3
           \sigma*(2B + cn + 3) = \sigma*(B + 97.5)/2^127 in Theorem 3.1
@@ -463,6 +469,7 @@ For this AEAD, n = 128, t = 128, and r = 96; the key length is k = 128 or k = 25
         - 5th term (2^(-r/2)):  = 2^48
 -->
 Protocols with nonce randomization have a limit of:
+
 ~~~
 AEA <= ((q+v)*l*B / 2^127) + (1 / 2^48)
 ~~~
@@ -474,20 +481,18 @@ q + v <= (p * 2^127 - 2^79) / (l * B)
 ~~~
 
 This assumes that B is much larger than 100; that is, each user enciphers
-significantly more than 1600 bytes of data.  If that does not hold, a lower
-limit applies:
+significantly more than 1600 bytes of data.  B should be increased by 97.5 for
+AEAD_AES_128_GCM and by 97 for AEAD_AES_256_GCM.
+
+Protocols without nonce randomization have limits that are substantially the
+same provided that p is not less than 2<sup>-48</sup>, as the simplified
+expression for AEA does not include the 2<sup>-48</sup> term:
 
 ~~~
-q + v <= (p * 2^127 - 2^79) / (l * (B + 97))
+q + v <= p * 2^127 / (l * B)
 ~~~
 
-Protocols without nonce randomization have limit that is substantially the same
-provided that p is not less than 2<sup>-48</sup>, as the simplified expression
-for AEA does not include the 2<sup>-48</sup> term:
-
-~~~
-q + v <= p * 2^127 / (l * (B + 97.5))
-~~~
+Without nonce randomization, B should be increased by an additional 0.5.
 
 
 ### Confidentiality Limit
@@ -515,13 +520,13 @@ CA <= (q*l*B / 2^127) + (1 / 2^48)
 This implies the following limit:
 
 ~~~
-q <= (p * 2^127 - 2^79) / (l * (B + 97))
+q <= (p * 2^127 - 2^79) / (l * B)
 ~~~
 
 As before, the limit without nonce randomization is:
 
 ~~~
-q <= (p * 2^127) / (l * (B + 97.5))
+q <= (p * 2^127) / (l * B)
 ~~~
 
 

--- a/draft-irtf-cfrg-aead-limits.md
+++ b/draft-irtf-cfrg-aead-limits.md
@@ -458,7 +458,7 @@ For this AEAD, n = 128, t = 128, and r = 96; the key length is k = 128 or k =
           For o <= 2^70 and B >= 2^8, it is dominated by the 2nd term;
             we assume that and hence omit the 1st term.
           If B is small and k = 128, then \sigma might be relevant and
-            we can add \sigma/2^128
+            we can add n*\sigma/2^128
         - 2nd term (../2^n):
           \sigma*(2B + cn + 2) = \sigma*(B + 97)/2^127 in Theorem 4.3
           \sigma*(2B + cn + 3) = \sigma*(B + 97.5)/2^127 in Theorem 3.1
@@ -492,7 +492,7 @@ expression for AEA does not include the 2<sup>-48</sup> term:
 q + v <= p * 2^127 / (l * B)
 ~~~
 
-Without nonce randomization, B should be increased by an additional 0.5.
+Without nonce randomization, B should be increased by an additional 64.
 
 
 ### Confidentiality Limit


### PR DESCRIPTION
I did some analysis of Theorem 3.1 in the GCM MU paper.

The difference is small.  Theorem 3.1 adds `σ/2^128` to the advantage.
Theorem 4.3 adds `1/2^48` to the advantage.

The difference is felt when `σ` gets large, then nonce randomization
gets better.  It's not as small a value as I had expected (2^80 is a
LARGE number) based on the original Bellare/Tackmann work, but it's
there.

I restored the constant factor from the second term to the equations.  
I tried a few things, but forcing a minimum on B seemed like it would be safest.

This is for yaronf/I-D#203.