### PR TITLE
ChaCha20Poly1305 multi-key bounds

### DIFF
--- a/draft-irtf-cfrg-aead-limits.md
+++ b/draft-irtf-cfrg-aead-limits.md
@@ -90,15 +90,7 @@ normative:
       - ins: V. T. Hoang
       - ins: S. Tessaro
       - ins: A. Thiruvengadam
-  ChaCha20Poly1305-MU:
-    title: "The Security of ChaCha20-Poly1305 in the Multi-User Setting"
-    target: https://doi.org/10.1145/3460120.3484814
-    date: 2021-11
-    author: 
-      - ins: J. P. Degabriele
-      - ins: J. Govinden
-      - ins: F. Günther
-      - ins: K. Paterson
+  ChaCha20Poly1305-MU: DOI.10.1145/3460120.3484814
 
 
 informative:
@@ -371,7 +363,6 @@ single expression, covered below. For this AEAD, n = 512, k = 256, and t = 128;
 the length l is the sum of AAD and plaintext (in blocks of 128 bits),
 see {{ChaCha20Poly1305-MU}}.
 
-<!-- I've got to say that this is a pretty unsatisfactory situation. -->
 
 <!--
     In {{ChaCha20Poly1305-SU}}, L is |AAD| + |plaintext| + 1; the + 1 is one
@@ -747,7 +738,7 @@ of AAD and plaintext (in blocks of 128 bits).
           This is dominated by the 1st term as long as B + q < 2^205;
           i.e., negligible and we hence omit it.
         
-        - 6th term:  1/2^(2t-2) = 2^-126
+        - 6th term:  1/2^(2t-2) = 2^-254
           This is negligible, we hence omit it.
         
         - 7th term:  1/2^(n - k - 2) = 2^-254
@@ -778,7 +769,7 @@ is calculated across all used keys.
 
 <!--
     From {{ChaCha20Poly1305-MU}} Theorem 7.8
-    substracting terms for Pr[Bad_5] and Pr[Bad_6],
+    subtracting terms for Pr[Bad_5] and Pr[Bad_6],
     and applying simplifications as above (note there are no verification queries),
     the remaining relevant terms are:
     
@@ -886,8 +877,8 @@ might be chosen under these conditions.
 
 The limits for AEAD_AES_128_GCM, AEAD_AES_256_GCM, AEAD_AES_128_CCM, and
 AEAD_AES_128_CCM_8 assume equal proportions for q and v. The limits for
-AEAD_AES_128_GCM, AEAD_AES_256_GCM and AEAD_CHACHA20_POLY1305 assume nonce
-randomization being deployed, like in TLS 1.3 {{TLS}} and QUIC {{?RFC9001}}.
+AEAD_AES_128_GCM, AEAD_AES_256_GCM and AEAD_CHACHA20_POLY1305 assume the use
+of nonce randomization, like in TLS 1.3 {{TLS}} and QUIC {{?RFC9001}}.
 
 The limits for AEAD_AES_128_GCM and AEAD_AES_256_GCM further depend on the
 maximum number B of 128-bit blocks encrypted by any single key. For example,

--- a/draft-irtf-cfrg-aead-limits.md
+++ b/draft-irtf-cfrg-aead-limits.md
@@ -895,11 +895,11 @@ q can be increased to 2<sup>31</sup>/sqrt(u) for both CCM AEADs.
 # Security Considerations {#sec-considerations}
 
 The different analyses of AEAD functions that this work is based upon generally
-assume that the underlying primitives are ideal.  For example, that the
-pseudorandom function (PRF) or pseudorandom permutation (PRP) the AEAD builds
-upon is indistinguishable from a truly random function, resp. permutation.
-Thus, the advantage estimates assume that the attacker is not able to exploit
-a weakness in an underlying primitive.
+assume that the underlying primitives are ideal.  For example, that a
+pseudorandom function (PRF) used by the AEAD is indistinguishable from a truly
+random function or that a pseudorandom permutation (PRP) is indistinguishable
+from a truly random permutation. Thus, the advantage estimates assume that the
+attacker is not able to exploit a weakness in an underlying primitive.
 
 Many of the formulae in this document depend on simplifying assumptions,
 from differing models, which means that results are not universally applicable. When using this

--- a/draft-irtf-cfrg-aead-limits.md
+++ b/draft-irtf-cfrg-aead-limits.md
@@ -726,6 +726,10 @@ of AAD and plaintext (in blocks of 128 bits).
         
         - 2nd term:  d(o + q)/2^k
           For d < 2^9 (as above) and o + q <= 2^145, this is dominated by the 1st term;
+          [[ 1st term <= 2nd term as long as v * (l + 1)/2^103 <= d(o + q)/2^256;
+          i.e., o + q <= v * (l + 1) * 2^153 / d.
+          Even for minimal values v = 1 and l = 1 in 1st term, with d < 2^9,
+          this holds as long as o + q <= 2^145. ]]
             we assume that and hence omit the 2nd term.
         
         - 3rd term:  2o * (n - k)/2^k

--- a/draft-irtf-cfrg-aead-limits.md
+++ b/draft-irtf-cfrg-aead-limits.md
@@ -655,23 +655,23 @@ q + v <= min( sqrt(p) * 2^76,  p * 2^126 / (l * B) )
     we obtain:
 
     Adv^{mu-ae w/o INT}_RCAU <=
-        2^8 * (o + q) / 2^k   +  \sigma*B/2^127  +  2^48
+        2^8 * (o + q) / 2^k   +  \sigma*B/2^127
 
     For o <= 2^70 and any B, the 1st term is dominated by the 2nd term;
     we assume that and hence again omit the 1st term.
 -->
 
-The confidentiality advantage is essentially dominated by the same terms as
+The confidentiality advantage is essentially dominated by the same term as
 the AE advantage for protocols with nonce randomization:
 
 ~~~
-CA <= (q*l*B / 2^127) + (1 / 2^48)
+CA <= q*l*B / 2^127
 ~~~
 
 This implies the following limit:
 
 ~~~
-q <= (p * 2^127 - 2^79) / (l * B)
+q <= p * 2^127 / (l * B)
 ~~~
 
 

--- a/draft-irtf-cfrg-aead-limits.md
+++ b/draft-irtf-cfrg-aead-limits.md
@@ -439,7 +439,7 @@ In a setting where `v` or `q` is sufficiently large, `v` is negligible compared 
 `(2l * (v + q))^2`, so this this can be simplified to:
 
 ~~~
-v + q <= p^(1/2) * 2^63 / l
+v + q <= sqrt(p) * 2^63 / l
 ~~~
 
 ## AEAD_AES_128_CCM_8
@@ -464,7 +464,7 @@ v * 2^64 + (2l * (v + q))^2 <= p * 2^128
 An example protocol might choose to aim for a single-key CA and IA that is at
 most 2<sup>-50</sup>.  If the messages exchanged in the protocol are at most a
 common Internet MTU of around 1500 bytes, then a value for l might be set to
-2<sup>7</sup>.  The values in {{ex-table}} show values of q and v that might be
+2<sup>7</sup>.  {{ex-table-su}} shows limits for q and v that might be
 chosen under these conditions.
 
 | AEAD                   | Maximum q        | Maximum v      |
@@ -474,7 +474,7 @@ chosen under these conditions.
 | AEAD_CHACHA20_POLY1305 | n/a              | 2<sup>46</sup> |
 | AEAD_AES_128_CCM       | 2<sup>30</sup>   | 2<sup>30</sup> |
 | AEAD_AES_128_CCM_8     | 2<sup>30.9</sup> | 2<sup>13</sup> |
-{: #ex-table title="Example limits"}
+{: #ex-table-su title="Example single-key limits"}
 
 AEAD_CHACHA20_POLY1305 provides no limit to q based on the provided single-user
 analyses.
@@ -482,7 +482,7 @@ analyses.
 The limit for q on AEAD_AES_128_CCM and AEAD_AES_128_CCM_8 is reduced due to a
 need to reduce the value of q to ensure that IA does not exceed the target.
 This assumes equal proportions for q and v for AEAD_AES_128_CCM.
-AEAD_AES_128_CCM_8 in permits a much smaller value of v due to the shorter tag,
+AEAD_AES_128_CCM_8 permits a much smaller value of v due to the shorter tag,
 which permits a higher limit for q.
 
 Some protocols naturally limit v to 1, such as TCP-based variants of TLS, which
@@ -857,7 +857,7 @@ integrity limits is replaced with `p / u`.
 The multi-key integrity limit for AEAD_AES_128_CCM is as follows.
 
 ~~~
-v + q <= (p / u)^(1/2) * 2^63 / l
+v + q <= sqrt(p / u) * 2^63 / l
 ~~~
 
 Likewise, the multi-key integrity limit for AEAD_AES_128_CCM_8 is as follows.
@@ -865,6 +865,41 @@ Likewise, the multi-key integrity limit for AEAD_AES_128_CCM_8 is as follows.
 ~~~
 v * 2^64 + (2l * (v + q))^2 <= (p / u) * 2^128
 ~~~
+
+
+## Multi-Key Examples
+
+An example protocol might choose to aim for a multi-key AEA, CA, and IA that is at
+most 2<sup>-50</sup>.  If the messages exchanged in the protocol are at most a
+common Internet MTU of around 1500 bytes, then a value for l might be set to
+2<sup>7</sup>.  {{ex-table-mu}} shows limits for q and v across all keys that
+might be chosen under these conditions.
+
+| AEAD                   | Maximum q                | Maximum v              |
+|:-----------------------|-------------------------:|-----------------------:|
+| AEAD_AES_128_GCM       | 2<sup>69</sup>/B         | 2<sup>69</sup>/B       |
+| AEAD_AES_256_GCM       | 2<sup>69</sup>/B         | 2<sup>69</sup>/B       |
+| AEAD_CHACHA20_POLY1305 | 2<sup>100</sup>          | 2<sup>46</sup>         |
+| AEAD_AES_128_CCM       | 2<sup>30</sup>/sqrt(u)   | 2<sup>30</sup>/sqrt(u) |
+| AEAD_AES_128_CCM_8     | 2<sup>30.9</sup>/sqrt(u) | 2<sup>13</sup>/u |
+{: #ex-table-mu title="Example multi-key limits"}
+
+The limits for AEAD_AES_128_GCM, AEAD_AES_256_GCM, AEAD_AES_128_CCM, and
+AEAD_AES_128_CCM_8 assume equal proportions for q and v. The limits for
+AEAD_AES_128_GCM, AEAD_AES_256_GCM and AEAD_CHACHA20_POLY1305 assume nonce
+randomization being deployed, like in TLS 1.3 {{TLS}} and QUIC {{?RFC9001}}.
+
+The limits for AEAD_AES_128_GCM and AEAD_AES_256_GCM further depend on the
+maximum number B of 128-bit blocks encrypted by any single key. For example,
+limiting each key to encrypt at most 2^20 (about a million) messages (of size
+around 1500 bytes as above), this results in B = 2^27 and hence limits for
+q and v of 2^42 messages that can be protected resp. forgery attempts that can
+be tolerated.
+
+Only the limits for AEAD_AES_128_CCM and AEAD_AES_128_CCM_8 depend on the number
+of used keys u, which further reduces them considerably. If v is limited to 1,
+q can be increased to 2<sup>31</sup>/sqrt(u) for both CCM AEADs.
+
 
 # Security Considerations {#sec-considerations}
 

--- a/draft-irtf-cfrg-aead-limits.md
+++ b/draft-irtf-cfrg-aead-limits.md
@@ -511,7 +511,8 @@ Alongside each value, we also specify these bounds.
 Concrete multi-key bounds for AEAD_AES_128_GCM and AEAD_AES_256_GCM exist due to
 Theorem 4.3 in {{GCM-MU2}}, which covers protocols with nonce randomization,
 like TLS 1.3 {{TLS}} and QUIC {{?RFC9001}}. Here, the full nonce is XORed with
-a secret, random offset.
+a secret, random offset. The bound for nonce randomization was further improved
+in {{ChaCha20Poly1305-MU}}.
 
 Results for AES-GCM with random, partially implicit nonces {{?RFC5288}} are
 captured by Theorem 5.3 in {{GCM-MU2}}, which apply to protocols such as
@@ -551,18 +552,25 @@ For this AEAD, n = 128, t = 128, and r = 96; the key length is k = 128 or k =
         - 3rd term (../2^2n):  <= 2^-160, negligible.
         - 4th term (../2^(k+n)):  roughly <= (\sigma^2 + 2o(q+v)) / 2^256
           <= 2^-64, negligible.
-        - 5th term (2^(-r/2)):  = 2^48
+        - 5th term (2^(-r/2)):  = 2^-48
+    
+    The 5th term, ensuring that the adversary is d-repeating ({{GCM-MU2}},
+    Theorem 4.2), was improved in {{ChaCha20Poly1305-MU}} Theorem 7.7 to
+      2^-(\delta * r)
+    for which \delta can be chosen as \delta = 2 for d < 2^9.
+    As d < 2^9 does not affect the above simplifications, this only makes the
+    5th term negligible (2^-192), and allows to omit it.
 -->
 Protocols with nonce randomization have a limit of:
 
 ~~~
-AEA <= ((q+v)*l*B / 2^127) + (1 / 2^48)
+AEA <= (q+v)*l*B / 2^127
 ~~~
 
 This implies the following limit:
 
 ~~~
-q + v <= (p * 2^127 - 2^79) / (l * B)
+q + v <= p * 2^127 / (l * B)
 ~~~
 
 This assumes that B is much larger than 100; that is, each user enciphers
@@ -598,8 +606,7 @@ AEAD_AES_128_GCM and by 97 for AEAD_AES_256_GCM.
 -->
 
 Protocols with random, partially implicit nonces have the following limit,
-which is similar to that for nonce randomization provided that p is not less
-than 2<sup>-48</sup>:
+which is similar to that for nonce randomization:
 
 ~~~
 AEA <= (((q+v)*o + (q+v)^2) / 2^(k+26)) + ((q+v)*l*B / 2^127)

--- a/draft-irtf-cfrg-aead-limits.md
+++ b/draft-irtf-cfrg-aead-limits.md
@@ -882,10 +882,8 @@ of nonce randomization, like in TLS 1.3 {{TLS}} and QUIC {{?RFC9001}}.
 
 The limits for AEAD_AES_128_GCM and AEAD_AES_256_GCM further depend on the
 maximum number B of 128-bit blocks encrypted by any single key. For example,
-limiting each key to encrypt at most 2^20 (about a million) messages (of size
-around 1500 bytes as above), this results in B = 2^27 and hence limits for
-q and v of 2^42 messages that can be protected resp. forgery attempts that can
-be tolerated.
+limiting the number of messages (of size <= 2^7 blocks) to at most 2^20 (about a
+million) per key results in B = 2^27, which limits both q and v to 2^42 messages.
 
 Only the limits for AEAD_AES_128_CCM and AEAD_AES_128_CCM_8 depend on the number
 of used keys u, which further reduces them considerably. If v is limited to 1,


### PR DESCRIPTION
Added multi-key bounds from https://doi.org/10.1145/3460120.3484814  (CCS 2021).

- ChaCha20Poly1305 has multi-key AE and integrity limit identical to single-user case (just that `v` is counted across all keys), multi-key confdentiality limit is bounded at very low levels
- multi-key GCM bound improved: the above work shows that the constant additive 2^-48 term can be waived without further side-effects on the dominant terms
- added multi-key examples (table)