### PR TITLE
Simplify CA for ChaCha

### DIFF
--- a/draft-irtf-cfrg-aead-limits.md
+++ b/draft-irtf-cfrg-aead-limits.md
@@ -372,7 +372,7 @@ see {{ChaCha20Poly1305-MU}}.
 <!--
     In {{ChaCha20Poly1305-SU}}, L is |AAD| + |plaintext| + 1; the + 1 is one
     block length encoding.
-    
+
     From {{ChaCha20Poly1305-MU}} Theorem 4.1 / 3.4:
       AE <= v * 2^25 * (l+1) / 2^t
     where t = 128.
@@ -549,7 +549,7 @@ For this AEAD, n = 128, t = 128, and r = 96; the key length is k = 128 or k =
         - 4th term (../2^(k+n)):  roughly <= (\sigma^2 + 2o(q+v)) / 2^256
           <= 2^-64, negligible.
         - 5th term (2^(-r/2)):  = 2^-48
-    
+
     The 5th term, ensuring that the adversary is d-repeating ({{GCM-MU2}},
     Theorem 4.2), was improved in {{ChaCha20Poly1305-MU}} Theorem 7.7 to
       2^-(\delta * r)
@@ -715,20 +715,20 @@ of AAD and plaintext (in blocks of 128 bits).
 
 <!--
     From {{ChaCha20Poly1305-MU}} Theorem 7.8; for nonce randomization (XN transform).
-    
+
     Let:
         - d: the max. number of times any nonce is repeated across users
         - \delta: the nonce-randomizer result's parameter
         - d = r * (\delta + 1) - 1 < 2^9, \delta = 2 be fixed, satisfying Theorem 7.8
         - this limits the number of encryption queries to q <= r * 2^(r-1) <= 2^101
         - o, B <= 2^261 as required for Theorem 7.8
-    
+
     We can simplify the Theorem 7.8 advantage bound as follows:
         - 1st term:  v([constant]* l + 3)/2^t
           Via Theorem 3.4, the more precise term is:  v * (2^25 * (l + 1) + 3) / 2^128
           The 3v/2^t summand is dominated by the rest, so we simplify to
             (v * (l + 1)) / 2^103
-        
+
         - 2nd term:  d(o + q)/2^k
           For d < 2^9 (as above) and o + q <= 2^145, this is dominated by the 1st term;
           [[ 1st term <= 2nd term as long as v * (l + 1)/2^103 <= d(o + q)/2^256;
@@ -736,23 +736,23 @@ of AAD and plaintext (in blocks of 128 bits).
           Even for minimal values v = 1 and l = 1 in 1st term, with d < 2^9,
           this holds as long as o + q <= 2^145. ]]
             we assume that and hence omit the 2nd term.
-        
+
         - 3rd term:  2o * (n - k)/2^k
           This is dominated by the 2nd term; we hence omit it.
-        
+
         - 4th term:  2v * (n - k + 4t)/2^k
           This is dominated by the 1st term; we hence omit it.
-        
+
         - 5th term:  (B + q)^2/2^(n+1)
           This is dominated by the 1st term as long as B + q < 2^205;
           i.e., negligible and we hence omit it.
-        
+
         - 6th term:  1/2^(2t-2) = 2^-254
           This is negligible, we hence omit it.
-        
+
         - 7th term:  1/2^(n - k - 2) = 2^-254
           This is negligible, we hence omit it.
-        
+
         - 8th term:  1/(\delta * r)
           This is 2^-192 for the chosen \delta = 2, hence negligible and we omit it.
 -->
@@ -781,17 +781,17 @@ is calculated across all used keys.
     subtracting terms for Pr[Bad_5] and Pr[Bad_6],
     and applying simplifications as above (note there are no verification queries),
     the remaining relevant terms are:
-    
+
         - 2nd term:  d(o + q)/2^k
           As d < 2^9, this is upper bounded by   (o+q)/2^247
-        
+
         - 3rd term:  2o * (n - k)/2^k
           This is  o/2^247 , dominated by the 2nd term; we hence omit it.
-        
+
         - 5th term:  (B + q)^2/2^(n+1)
           This is dominated by the 2nd term as long as B + q < sqrt(o+q) * 2^133;
           i.e., likely negligible in comparison, but we include it as both are small.
-        
+
         - 8th term:  1/(\delta * r)
           This is 2^-192 for the chosen \delta = 2, hence negligible and we omit it.
 -->
@@ -821,7 +821,7 @@ CA <= ((o + q) / 2^247) + ((B + q)^2 / 2^513)
       q <= (p * 2^246) - o
       AND
       q <= sqrt(p) * 2^256 - B
-    
+
     In addition, the restrictions on q from {{ChaCha20Poly1305-MU}} Theorem 7.8
     applies: q <= r * 2^(r-1) <= 2^101.
     We round this to 2^100; this value can be slightly increased trading off d.

--- a/draft-irtf-cfrg-aead-limits.md
+++ b/draft-irtf-cfrg-aead-limits.md
@@ -799,7 +799,8 @@ is calculated across all used keys.
           Even with a single user and a single key such that B = q * l, and no
           offline work from the adversary (o = 0) the term is only relevant when
           q * l = sqrt(q) * 2^133.  With q capped at 2^100, the smallest value
-          of l that can result from this is 2^83, which is impractically large.
+          of l that can result from this is 2^83, which far exceeds the maximum
+          size of a single message at 2^32.
 
         - 8th term:  1/(\delta * r)
           This is 2^-192 for the chosen \delta = 2, hence negligible and we omit it.

--- a/draft-irtf-cfrg-aead-limits.md
+++ b/draft-irtf-cfrg-aead-limits.md
@@ -789,49 +789,43 @@ is calculated across all used keys.
           This is  o/2^247 , dominated by the 2nd term; we hence omit it.
 
         - 5th term:  (B + q)^2/2^(n+1)
-          This is dominated by the 2nd term as long as B + q < sqrt(o+q) * 2^133;
-          i.e., likely negligible in comparison, but we include it as both are small.
+
+          This is dominated by the 2nd term as long as B + q < sqrt(o+q) * 2^133.
+
+          We omit this term on the basis that B <= q * l and there is no value
+          of q less than 2^100 (see below) for which B > sqrt(q) * 2^133 given
+          that constraint.
+
+          Even with a single user and a single key such that B = q * l, and no
+          offline work from the adversary (o = 0) the term is only relevant when
+          q * l = sqrt(q) * 2^133.  With q capped at 2^100, the smallest value
+          of l that can result from this is 2^83, which is impractically large.
 
         - 8th term:  1/(\delta * r)
           This is 2^-192 for the chosen \delta = 2, hence negligible and we omit it.
 -->
 
-While the AE advantage is dominated by the number of forgery attempts `v`,
-those are irrelevant for the confidentiality advantage. The relevant
-limit for protocols with nonce randomization becomes dominated, at a very low
-level, by the adversary's offline work `o`, number of protected messages `q`
-and maximum blocks encrypted `B`, across all used keys:
+While the AE advantage is dominated by the number of forgery attempts `v`, those
+are irrelevant for the confidentiality advantage. The relevant limit for
+protocols with nonce randomization becomes dominated, at a very low level, by
+the adversary's offline work `o`, and the number of protected messages `q`
+across all used keys:
 
 ~~~
-CA <= ((o + q) / 2^247) + ((B + q)^2 / 2^513)
+CA <= (o + q) / 2^247)
 ~~~
 
 <!--
-    Simplifying
-      p >= ((o + q) / 2^247) + ((B + q)^2 / 2^513)
-
-    to
-
-      p/2 >= (o + q) / 2^247
-      AND
-      p/2 >= (B + q)^2 / 2^513
-
-    yields
-
-      q <= (p * 2^246) - o
-      AND
-      q <= sqrt(p) * 2^256 - B
-
     In addition, the restrictions on q from {{ChaCha20Poly1305-MU}} Theorem 7.8
     applies: q <= r * 2^(r-1) <= 2^101.
     We round this to 2^100; this value can be slightly increased trading off d.
 -->
 
-It implies the following simplified limit, which for most reasonable values
-of `p` is dominated by a technical limitation around `q = 2^100`:
+This implies the following simplified limit, which for most reasonable values of
+`p` is dominated by a technical limitation of approximately `q = 2^100`:
 
 ~~~
-q <= min( p * 2^246 - o,  sqrt(p) * 2^256 - B, 2^100 )
+q <= min( p * 2^247 - o, 2^100 )
 ~~~
 
 


### PR DESCRIPTION
The extra term really isn't relevant here unless you have enormous messages.  By which I mean, messages that are 32 Yottabytes in size.  That's a single encryption of that size.  2^100 of those messages, with every one of them that big.  No rekeying either.

It's even less plausible for smaller q.  A q of 1 results in a message size of 2^139 bytes.

Neither is concretely possible as RFC 7539 has just a 32-bit counter, which limits messages to 256GB.