### PR TITLE
Use superscripts for multi-key example

### DIFF
--- a/draft-irtf-cfrg-aead-limits.md
+++ b/draft-irtf-cfrg-aead-limits.md
@@ -889,8 +889,9 @@ of nonce randomization, like in TLS 1.3 {{TLS}} and QUIC {{?RFC9001}}.
 
 The limits for AEAD_AES_128_GCM and AEAD_AES_256_GCM further depend on the
 maximum number B of 128-bit blocks encrypted by any single key. For example,
-limiting the number of messages (of size <= 2^7 blocks) to at most 2^20 (about a
-million) per key results in B = 2^27, which limits both q and v to 2^42 messages.
+limiting the number of messages (of size <= 2<sup>7</sup> blocks) to at most
+2<sup>20</sup> (about a million) per key results in B = 2<sup>27</sup>, which
+limits both q and v to 2<sup>42</sup> messages.
 
 Only the limits for AEAD_AES_128_CCM and AEAD_AES_128_CCM_8 depend on the number
 of used keys u, which further reduces them considerably. If v is limited to 1,


### PR DESCRIPTION
These are more readable in HTML this way.