### PR TITLE
Explain GCM IA and CCM CA bounds

### DIFF
--- a/draft-irtf-cfrg-aead-limits.md
+++ b/draft-irtf-cfrg-aead-limits.md
@@ -432,6 +432,17 @@ i.e., `2L` represents the effective length, in number of block cipher operations
 L blocks. This simplification is based on the observation that common applications of this AEAD carry
 only a small amount of associated data compared to ciphertext. For example, QUIC has 1 to 3 blocks of AAD.
 
+<!--
+    In {{!CCM-ANALYSIS=DOI.10.1007/3-540-36492-7_7}}, Theorem 1+2, the terms
+    l_E / l_F are the sum of block cipher applications over all encryption /
+    forgery calls, which count the number of message blocks twice: once as
+    |m| (resp. |c|), and once in the enconding function \beta.
+    
+    We simplify this by doubling the the packet length, using `2L` instead of
+    `L`, while ignoring the usually small additional overhead of associated data.
+    Hence `l_E = 2L * q` and `l_F = 2L * v`.
+-->
+
 For this AEAD, `n = 128` and `t = 128`.
 
 ### Confidentiality Limit

--- a/draft-irtf-cfrg-aead-limits.md
+++ b/draft-irtf-cfrg-aead-limits.md
@@ -379,6 +379,14 @@ q <= (p^(1/2) * 2^(129/2) - 1) / (L + 1)
 
 ### Integrity Limit
 
+<!--
+    We follow {{GCMProofs}} and use the improved integrity bound from
+    {{AEBounds}}, Equation (22), which gives the term (v * (L+1)) * \delta(...).
+    Assuming s + q + v < 2^64, one can bound \delta(...) <= 1.7 <= 2.
+-->
+
+Assuming `s + q + v < 2^64` implies this bound:
+
 ~~~
 IA <= 2 * (v * (L + 1)) / 2^128
 ~~~
@@ -437,7 +445,7 @@ only a small amount of associated data compared to ciphertext. For example, QUIC
     l_E / l_F are the sum of block cipher applications over all encryption /
     forgery calls, which count the number of message blocks twice: once as
     |m| (resp. |c|), and once in the enconding function \beta.
-    
+
     We simplify this by doubling the the packet length, using `2L` instead of
     `L`, while ignoring the usually small additional overhead of associated data.
     Hence `l_E = 2L * q` and `l_F = 2L * v`.

--- a/draft-irtf-cfrg-aead-limits.md
+++ b/draft-irtf-cfrg-aead-limits.md
@@ -380,8 +380,8 @@ q <= (p^(1/2) * 2^(129/2) - 1) / (L + 1)
 ### Integrity Limit
 
 <!--
-    We follow {{GCMProofs}} and use the improved integrity bound from
-    {{AEBounds}}, Equation (22), which gives the term (v * (L+1)) * \delta(...).
+    We follow {{AEBounds}} and use the improved integrity bound from
+    {{GCMProofs}}, Equation (22), which gives the term (v * (L+1)) * \delta(...).
     Assuming s + q + v < 2^64, one can bound \delta(...) <= 1.7 <= 2.
 -->
 

--- a/draft-irtf-cfrg-aead-limits.md
+++ b/draft-irtf-cfrg-aead-limits.md
@@ -379,13 +379,9 @@ q <= (p^(1/2) * 2^(129/2) - 1) / (L + 1)
 
 ### Integrity Limit
 
-<!--
-    We follow {{AEBounds}} and use the improved integrity bound from
-    {{GCMProofs}}, Equation (22), which gives the term (v * (L+1)) * \delta(...).
-    Assuming s + q + v < 2^64, one can bound \delta(...) <= 1.7 <= 2.
--->
-
-Assuming `s + q + v < 2^64` implies this bound:
+Applying Equation (22) from {{GCMProofs}}, in which the assumption of
+`s + q + v < 2^64` ensures that the delta function cannot produce a value
+greater than 2, the following bound applies:
 
 ~~~
 IA <= 2 * (v * (L + 1)) / 2^128
@@ -444,7 +440,7 @@ only a small amount of associated data compared to ciphertext. For example, QUIC
     In {{!CCM-ANALYSIS=DOI.10.1007/3-540-36492-7_7}}, Theorem 1+2, the terms
     l_E / l_F are the sum of block cipher applications over all encryption /
     forgery calls, which count the number of message blocks twice: once as
-    |m| (resp. |c|), and once in the enconding function \beta.
+    |m| (resp. |c|), and once in the encoding function \beta.
 
     We simplify this by doubling the the packet length, using `2L` instead of
     `L`, while ignoring the usually small additional overhead of associated data.


### PR DESCRIPTION
Following up on Scott Fluhrer's CFRG review (Feb 14, 2023), I've added explanations for two bounds:

1. **GCM integrity**: We're using an improved bound (as in {{AEBounds}}) from {{GCMProofs}, Equation (22), where the second term mentioned in #55 vanishes by applying a result from Bernstein on random permutations.
2. **CCM confidentiality**: The `2L` here comes from the way message blocks are counted twice for the terms `l_E` (or `l_F`) in {{!CCM-ANALYSIS=DOI.10.1007/3-540-36492-7_7}}, not from counting `l_E + l_F` (that's integrity, and hence `2L * (q + v)` there).

I.e., in both cases the bounds as stated are correct, but I thought that added explanation would be helpful.