### PR TITLE
Number of forgery attempts

### DIFF
--- a/draft-irtf-cfrg-aead-limits.md
+++ b/draft-irtf-cfrg-aead-limits.md
@@ -214,7 +214,7 @@ This document defines limitations in part using the quantities in
 | L | Maximum length of each message (in blocks) |
 | s | Total plaintext length in all messages (in blocks) |
 | q | Number of protected messages (AEAD encryption invocations) |
-| v | Number of attacker forgery attempts (failed AEAD decryption invocations) |
+| v | Number of attacker forgery attempts (failed AEAD decryption invocations + 1) |
 | p | Upper bound on adversary attack probability |
 | o | Offline adversary work (in number of encryption and decryption queries; multi-key setting only) |
 | u | Number of keys (multi-key setting only) |


### PR DESCRIPTION
Number of forgery attempts should include the "ongoing one" for which we provide a bound. I.e., if the attacker made `x` (failed) attempts already, then the bounds are for `v = x + 1` attempts / decryption queries overall.

This is in response to John Mattsson's comment:

> In their paper “Breaking and Repairing GCM Security Proofs”, Iwata, Ohashi, and Minematsu define the variable q′ to be decryption queries. The draft instead uses v to mean failed AEAD decryption invocations. The idea to replace “decryption queries” with “failed AEAD decryption invocations” is very good but causes some problems.
> 
> IA <= 2 * (v * (L + 1)) / 2^128
> v - Number of attacker forgery attempts (failed AEAD decryption invocations)            
> 
> When using the formulas in the paper, it’s clear that q’ is 1 in the first forgery attempt.
> When using the formulas in the draft it’s not clear the v is 1 in the first forgery attempt.
> 
> Wrongly using v = 0 gives the incorrect probability of 1 / 2^128 for a successful forgery which is much better than the correct value of 1 / 2^116.

Indeed the probability for the first forgery attempt should be using v = 1, so it's "0 past attempts + 1".

I'm not sure I follow the 2^116 bound, though.  (Also, with the current term and `v = 0`, IA would be 0.)