### PR TITLE
Add a note about offline work

### DIFF
--- a/draft-irtf-cfrg-aead-limits.md
+++ b/draft-irtf-cfrg-aead-limits.md
@@ -371,15 +371,14 @@ key search (in the key length, `k`) given sufficient resources.
 
 An attacker that is able to deploy sufficient offline resources (`o`) can
 increase their success probability independent of any usage.  In even the best
-case, single key bounds are always additionally limited to:
+case, single key bounds are always limited to the maximum of the stated bound and
 
 ~~~
 AEA <= o / 2^k
 ~~~
 
-This places a bound on the advantage that can be achieved for modes that use
-smaller key sizes, depending on what assumptions can be made about attacker
-resources.
+This constrains the security that can be achieved for modes that use smaller key
+sizes, depending on what assumptions can be made about attacker resources.
 
 For example, if an attacker could be assumed to have the resources to perform in
 the order of 2^80 AES operations, an attacker gains an attack probability of

--- a/draft-irtf-cfrg-aead-limits.md
+++ b/draft-irtf-cfrg-aead-limits.md
@@ -690,7 +690,8 @@ q + v <= p * 2^127 / (L * B)
 
 This assumes that `B` is much larger than 100; that is, each user enciphers
 significantly more than 1600 bytes of data.  Otherwise, `B` should be increased by 161 for
-AEAD_AES_128_GCM and by 97 for AEAD_AES_256_GCM.
+AEAD_AES_128_GCM and by 97 for AEAD_AES_256_GCM.  For AEAD_AES_128_GCM, it further assumes
+`o <= 2^70`, otherwise a term in the order of `o / 2^120` starts dominating.
 
 
 <!--

--- a/draft-irtf-cfrg-aead-limits.md
+++ b/draft-irtf-cfrg-aead-limits.md
@@ -971,7 +971,7 @@ factor `u`, i.e., the number of keys, each `p` term in the confidentiality and
 integrity limits is replaced with `p / u`.
 
 Note that this factor also applies to the generic exhaustive key search attack
-discussed for single-key analyses in {#offline-work}.
+discussed for single-key analyses in {{offline-work}}.
 
 The multi-key integrity limit for AEAD_AES_128_CCM is as follows.
 

--- a/draft-irtf-cfrg-aead-limits.md
+++ b/draft-irtf-cfrg-aead-limits.md
@@ -573,7 +573,8 @@ allocations tend to greatly reduce `q` without significantly increasing `v`.
 ## Single-Key Examples
 
 An example protocol might choose to aim for a single-key CA and IA that is at
-most 2<sup>-50</sup>.  If the messages exchanged in the protocol are at most a
+most 2<sup>-50</sup>.  (This in particular limits offline work to `o <= 2^(k-50)`,
+see {{offline-work}}.)  If the messages exchanged in the protocol are at most a
 common Internet MTU of around 1500 bytes, then a value for `L` might be set to
 2<sup>7</sup>.  {{ex-table-su}} shows limits for `q` and `v` that might be
 chosen under these conditions.
@@ -585,7 +586,7 @@ chosen under these conditions.
 | AEAD_CHACHA20_POLY1305 | n/a              | 2<sup>46</sup> |
 | AEAD_AES_128_CCM       | 2<sup>30</sup>   | 2<sup>30</sup> |
 | AEAD_AES_128_CCM_8     | 2<sup>30.4</sup> | 2<sup>13</sup> |
-{: #ex-table-su title="Example single-key limits"}
+{: #ex-table-su title="Example single-key limits; see text for parameter details"}
 
 AEAD_CHACHA20_POLY1305 provides no limit to `q` based on the provided single-user
 analyses.
@@ -1000,12 +1001,13 @@ might be chosen under these conditions.
 | AEAD_CHACHA20_POLY1305 | 2<sup>100</sup>          | 2<sup>46</sup>         |
 | AEAD_AES_128_CCM       | 2<sup>30</sup>/sqrt(u)   | 2<sup>30</sup>/sqrt(u) |
 | AEAD_AES_128_CCM_8     | 2<sup>30.9</sup>/sqrt(u) | 2<sup>13</sup>/u |
-{: #ex-table-mu title="Example multi-key limits"}
+{: #ex-table-mu title="Example multi-key limits; see text for parameter details"}
 
 The limits for AEAD_AES_128_GCM, AEAD_AES_256_GCM, AEAD_AES_128_CCM, and
 AEAD_AES_128_CCM_8 assume equal proportions for `q` and `v`. The limits for
 AEAD_AES_128_GCM, AEAD_AES_256_GCM and AEAD_CHACHA20_POLY1305 assume the use
-of nonce randomization, like in TLS 1.3 {{TLS}} and QUIC {{?RFC9001}}.
+of nonce randomization, like in TLS 1.3 {{TLS}} and QUIC {{?RFC9001}}, and
+offline work limited to `o <= 2^70`.
 
 The limits for AEAD_AES_128_GCM and AEAD_AES_256_GCM further depend on the
 maximum number (`B`) of 128-bit blocks encrypted by any single key. For example,
@@ -1015,7 +1017,8 @@ limits both `q` and `v` to 2<sup>42</sup> messages.
 
 Only the limits for AEAD_AES_128_CCM and AEAD_AES_128_CCM_8 depend on the number
 of used keys (`u`), which further reduces them considerably. If `v` is limited to 1,
-`q` can be increased to 2<sup>31</sup>/sqrt(u) for both CCM AEADs.
+`q` can be increased to 2<sup>31</sup>/sqrt(u) for both CCM AEADs. (In particular
+offline work is assumed limited to `o <= 2^(k-50) / u = 2^78 / u`, see {{offline-work}}.)
 
 
 # Security Considerations {#sec-considerations}

--- a/draft-irtf-cfrg-aead-limits.md
+++ b/draft-irtf-cfrg-aead-limits.md
@@ -342,34 +342,6 @@ nonces will not repeat, a nonce-misuse resistant AEAD like AES-GCM-SIV {{?SIV=RF
 likely to be a better choice.
 
 
-## Offline Work
-
-Analyses of different cipher modes typically concentrate on the advantage that
-an attacker might gain through the mode itself.  As noted, some analyses
-assume that the underlying cipher is an ideal PRP or PRF, and we make the same
-assumptions here.  But even an ideal PRP or PRF can be attacked through exchaustive
-key search (in the key length, `k`) given sufficient resources.
-
-An attacker that is able to deploy sufficient offline resources (`o`) can
-increase their success probability independent of any usage.  In even the best
-case, single key bounds are limited to:
-
-~~~
-AEA <= o / 2^k
-~~~
-
-This places a bound on the advantage that can be achieved for modes that use
-smaller key sizes, depending on what assumptions can be made about attacker
-resources.
-
-For example, if an attacker could be assumed to have the resources to perform in
-the order of 2^80 AES operations, an attacker gains an attack probability of
-2<sup>-48</sup>.  That might seem like it requires a lot of compute resources,
-but amount of compute could cost less than 1 million USD in 2025. That cost can
-only reduce over time, suggesting that a much greater advantage is likely
-achievable for a sufficiently motivated attacker.
-
-
 # Single-Key AEAD Limits {#su-limits}
 
 This section summarizes the confidentiality and integrity bounds and limits for modern AEAD algorithms
@@ -387,6 +359,35 @@ using a variable-length nonce for AES-GCM results in worse security bounds.
 
 The CL and IL values bound the total number of encryption and forgery queries (`q` and `v`).
 Alongside each advantage value, we also specify these bounds.
+
+
+## Offline Work {#offline-work}
+
+Single-key analyses of different cipher modes typically concentrate on the advantage
+that an attacker might gain through the mode itself.  These analyses
+assume that the underlying cipher is an ideal PRP or PRF, and we make the same
+assumptions here.  But even an ideal PRP or PRF can be attacked through exchaustive
+key search (in the key length, `k`) given sufficient resources.
+
+An attacker that is able to deploy sufficient offline resources (`o`) can
+increase their success probability independent of any usage.  In even the best
+case, single key bounds are always additionally limited to:
+
+~~~
+AEA <= o / 2^k
+~~~
+
+This places a bound on the advantage that can be achieved for modes that use
+smaller key sizes, depending on what assumptions can be made about attacker
+resources.
+
+For example, if an attacker could be assumed to have the resources to perform in
+the order of 2^80 AES operations, an attacker gains an attack probability of
+2<sup>-48</sup>.  That might seem like it requires a lot of compute resources,
+but amount of compute could cost less than 1 million USD in 2025. That cost can
+only reduce over time, suggesting that a much greater advantage is likely
+achievable for a sufficiently motivated attacker.
+
 
 ## AEAD_AES_128_GCM and AEAD_AES_256_GCM
 
@@ -967,6 +968,9 @@ There are currently no concrete multi-key bounds for AEAD_AES_128_CCM or
 AEAD_AES_128_CCM_8. Thus, to account for the additional
 factor `u`, i.e., the number of keys, each `p` term in the confidentiality and
 integrity limits is replaced with `p / u`.
+
+Note that this factor also applies to the generic exhaustive key search attack
+discussed for single-key analyses in {#offline-work}.
 
 The multi-key integrity limit for AEAD_AES_128_CCM is as follows.
 

--- a/draft-irtf-cfrg-aead-limits.md
+++ b/draft-irtf-cfrg-aead-limits.md
@@ -366,7 +366,7 @@ Alongside each advantage value, we also specify these bounds.
 Single-key analyses of different cipher modes typically concentrate on the advantage
 that an attacker might gain through the mode itself.  These analyses
 assume that the underlying cipher is an ideal PRP or PRF, and we make the same
-assumptions here.  But even an ideal PRP or PRF can be attacked through exchaustive
+assumptions here.  But even an ideal PRP or PRF can be attacked through exhaustive
 key search (in the key length, `k`) given sufficient resources.
 
 An attacker that is able to deploy sufficient offline resources (`o`) can

--- a/draft-irtf-cfrg-aead-limits.md
+++ b/draft-irtf-cfrg-aead-limits.md
@@ -252,7 +252,8 @@ the ciphertext outputs of the AEAD scheme from the outputs of a random function
 or is able to forge a ciphertext that will be accepted as valid.
 
 Here, we consider advantages beyond distinguishing underyling primitives from their
-ideal instances (for example, a pseudorandom from a truly random function).
+ideal instances, for example, a blockcipher from a random permutation (PRP advantage)
+or a pseudorandom function from a truly random function (PRF advantage).
 
 See {{AEComposition}}, {{AEAD}} for the formal definitions of and relations
 between IND-CPA (confidentiality), INT-CTXT (integrity),
@@ -343,23 +344,22 @@ likely to be a better choice.
 
 ## Offline Work
 
-Analysis of different cipher modes typically concentrates on the advantage that
-an attacker might gain through the mode itself.  As noted, the analyses tend to
-assume that the underlying cipher is an ideal PRP or PRF.  But even an ideal
-function can be attacked given sufficient resources.  The effectiveness an
-attack on an ideal PRP or PRF is determined by the internal state size (that is,
-the block size, `n`).
+Analyses of different cipher modes typically concentrate on the advantage that
+an attacker might gain through the mode itself.  As noted, some analyses
+assume that the underlying cipher is an ideal PRP or PRF, and we make the same
+assumptions here.  But even an ideal PRP or PRF can be attacked through exchaustive
+key search (in the key length, `k`) given sufficient resources.
 
 An attacker that is able to deploy sufficient offline resources (`o`) can
 increase their success probability independent of any usage.  In even the best
 case, single key bounds are limited to:
 
 ~~~
-AEA <= o / 2^n
+AEA <= o / 2^k
 ~~~
 
 This places a bound on the advantage that can be achieved for modes that use
-smaller block sizes, depending on what assumptions can be made about attacker
+smaller key sizes, depending on what assumptions can be made about attacker
 resources.
 
 For example, if an attacker could be assumed to have the resources to perform in

--- a/draft-irtf-cfrg-aead-limits.md
+++ b/draft-irtf-cfrg-aead-limits.md
@@ -220,7 +220,7 @@ This document defines limitations in part using the quantities in
 | q | Number of protected messages (AEAD encryption invocations) |
 | v | Number of attacker forgery attempts (failed AEAD decryption invocations + 1) |
 | p | Upper bound on adversary attack probability |
-| o | Offline adversary work (time, measured in number of encryption and decryption queries; multi-key setting only) |
+| o | Offline adversary work (measured in number of encryption and decryption queries) |
 | u | Number of keys (multi-key setting only) |
 | B | Maximum number of blocks encrypted by any key (multi-key setting only) |
 {: #notation-table title="Notation"}
@@ -339,6 +339,35 @@ protect different messages, so deterministic generation of nonces from a counter
 similar techniques is strongly encouraged.  If an application cannot guarantee that
 nonces will not repeat, a nonce-misuse resistant AEAD like AES-GCM-SIV {{?SIV=RFC8452}} is
 likely to be a better choice.
+
+
+## Offline Work
+
+Analysis of different cipher modes typically concentrates on the advantage that
+an attacker might gain through the mode itself.  As noted, the analyses tend to
+assume that the underlying cipher is an ideal PRP or PRF.  But even an ideal
+function can be attacked given sufficient resources.  The effectiveness an
+attack on an ideal PRP or PRF is determined by the internal state size (that is,
+the block size, `n`).
+
+An attacker that is able to deploy sufficient offline resources (`o`) can
+increase their success probability independent of any usage.  In even the best
+case, single key bounds are limited to:
+
+~~~
+AEA <= o / 2^n
+~~~
+
+This places a bound on the advantage that can be achieved for modes that use
+smaller block sizes, depending on what assumptions can be made about attacker
+resources.
+
+For example, if an attacker could be assumed to have the resources to perform in
+the order of 2^80 AES operations, an attacker gains an attack probability of
+2<sup>-48</sup>.  That might seem like it requires a lot of compute resources,
+but amount of compute could cost less than 1 million USD in 2025. That cost can
+only reduce over time, suggesting that a much greater advantage is likely
+achievable for a sufficiently motivated attacker.
 
 
 # Single-Key AEAD Limits {#su-limits}


### PR DESCRIPTION
I spent far too much time trying to find independent ways to reproduce djb's cost estimates, but was unable to make a significant dent in that. Still, that's not the central point here, so I'm keeping them.

To give an example, c8g.metal-24xl instances have a spot price of less than USD1 per hour (https://instances.vantage.sh/aws/ec2/c8g.metal-24xl). If we assume that those are capable of performance roughly on par with my own machine, but with 6 times the parallel capacity, then they should be easily capable of 3 billion blocks per second or 2^43 blocks per hour. Spending USD1MM would therefore mean 2^63 blocks, which is a long way short of the above estimate.