### PR TITLE
Proof comments

### DIFF
--- a/draft-irtf-cfrg-aead-limits.md
+++ b/draft-irtf-cfrg-aead-limits.md
@@ -361,11 +361,19 @@ Alongside each advantage value, we also specify these bounds.
 
 ## AEAD_AES_128_GCM and AEAD_AES_256_GCM
 
-The CL and IL values for AES-GCM are derived in {{AEBounds}} and summarized below.
+The CL and IL values for AES-GCM are derived in {{AEBounds}}, following {{GCMProofs}}, and summarized below.
 For this AEAD, `n = 128` (the AES block length) and `t = 128` {{GCM}}, {{!RFC5116}}. In this example,
 the length `s` is the sum of AAD and plaintext (in blocks of 128 bits), as described in {{GCMProofs}}.
 
 ### Confidentiality Limit
+
+Applying Corollary 3 from {{GCMProofs}}, assuming AES behaves like a random permutation,
+the following bound applies:
+
+<!--
+    Corollary 3 in {{GCMProofs}} states this bound for GCM with a random permutation;
+    so there is an additional PRP advantage term in the standard model (cf. offline work discussion).
+-->
 
 ~~~
 CA <= ((s + q + 1)^2) / 2^129
@@ -389,6 +397,11 @@ q <= (p^(1/2) * 2^(129/2) - 1) / (L + 1)
 Applying Equation (22) from {{GCMProofs}}, in which the assumption of
 `s + q + v < 2^64` ensures that the delta function cannot produce a value
 greater than 2, the following bound applies:
+
+<!--
+    Equation (22) in {{GCMProofs}} includes an additional PRP advantage term,
+    which we omit here (cf. offline work discussion).
+-->
 
 ~~~
 IA <= 2 * (v * (L + 1)) / 2^128

--- a/draft-irtf-cfrg-aead-limits.md
+++ b/draft-irtf-cfrg-aead-limits.md
@@ -440,9 +440,10 @@ and plaintext (in Poly1305 blocks of 128 bits), see {{ChaCha20Poly1305-MU}}.
 
     From {{ChaCha20Poly1305-MU}} Theorem 4.1:
       AEA <= PRF-advantage  +  v * 2^25 * (L'+1) / 2^t
-    where t = 128. The CA part of this is only the PRF advantage, as in the
-    proof of Theorem 4.1, the hops bounding G_3 only apply to the decryption
-    oracle. So CA beyond the PRF advantage is 0. (L' is in Poly1305 t bit blocks.)
+    where t = 128. The CA part of this is only the PRF advantage
+    (against the ChaCha20 block function). As in the proof of Theorem 4.1,
+    the hops bounding G_3 only apply to the decryption oracle.
+    So CA beyond the PRF advantage is 0. (L' is in Poly1305 t bit blocks.)
 -->
 
 ### Confidentiality Limit
@@ -489,6 +490,8 @@ only a small amount of associated data compared to ciphertext. For example, QUIC
     We simplify this by doubling the the packet length, using `2L` instead of
     `L`, while ignoring the usually small additional overhead of associated data.
     Hence `l_E = 2L * q` and `l_F = 2L * v`.
+
+    The bounds stated are those beyond the PRP security of the AES blockcipher.
 -->
 
 For this AEAD, `n = 128` (the AES block length) and `t = 128`.


### PR DESCRIPTION
Added details on PRP advantage being used for AES and PRF advantage being used for ChaCha20, to accompany the #70 Offline Work discussion.